### PR TITLE
Update parallel_louvain.cpp

### DIFF
--- a/src/parallel_louvain.cpp
+++ b/src/parallel_louvain.cpp
@@ -408,7 +408,7 @@ Rcpp::List parallel_louvain(NumericMatrix links, long num_vertices){
   modularity = find_communities(G,C_orig);
   
   for(auto it = clusterLocalMap.begin();it != clusterLocalMap.end(); ++it){
-    res[it->first]=(int)C_orig[it->second];
+    res[it->first-1]=(int)C_orig[it->second];
   }
   
   //printf("%d is the length of res 1\n",res.length());


### PR DESCRIPTION
Off by 1 index error when making community assignments to NumericVector res.  Node index values passed to fastPG should be 1 to N.  But res is a normal C++ array indexed from 0 to N-1.  Thus, when preparing the res NumericVector, we should remember that node index value $i should be stored in res at $i-1.  That way, back in R, users can see the community assignment for $i by looking at $res[$i].