### PR TITLE
Added new default options and ability to specify opts at parallel_lou…

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -22,7 +22,7 @@ rcpp_parallel_jce <- function(mat) {
 #' * `communities` - A vector where the i'th value is the
 #'   cluster number that the i'th node in the links matrix has been assigned to.
 #' @export
-parallel_louvain <- function(links) {
-    .Call(`_FastPG_parallel_louvain`, links)
+parallel_louvain <- function(links, minGraphSize = 1000L, C_thresh = 0.000001, threshold = 0.000000001, numColors = 16L, strongScaling = FALSE, coloring = 1L, syncType = 0L, basicOpt = 1L) {
+    .Call(`_FastPG_parallel_louvain`, links, minGraphSize, C_thresh, threshold, numColors, strongScaling, coloring, syncType, basicOpt)
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -28,13 +28,21 @@ BEGIN_RCPP
 END_RCPP
 }
 // parallel_louvain
-Rcpp::List parallel_louvain(NumericMatrix links);
-RcppExport SEXP _FastPG_parallel_louvain(SEXP linksSEXP) {
+Rcpp::List parallel_louvain(NumericMatrix links, int minGraphSize, double C_thresh, double threshold, int numColors, bool strongScaling, int coloring, int syncType, int basicOpt);
+RcppExport SEXP _FastPG_parallel_louvain(SEXP linksSEXP, SEXP minGraphSizeSEXP, SEXP C_threshSEXP, SEXP thresholdSEXP, SEXP numColorsSEXP, SEXP strongScalingSEXP, SEXP coloringSEXP, SEXP syncTypeSEXP, SEXP basicOptSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericMatrix >::type links(linksSEXP);
-    rcpp_result_gen = Rcpp::wrap(parallel_louvain(links));
+    Rcpp::traits::input_parameter< int >::type minGraphSize(minGraphSizeSEXP);
+    Rcpp::traits::input_parameter< double >::type C_thresh(C_threshSEXP);
+    Rcpp::traits::input_parameter< double >::type threshold(thresholdSEXP);
+    Rcpp::traits::input_parameter< int >::type numColors(numColorsSEXP);
+    Rcpp::traits::input_parameter< bool >::type strongScaling(strongScalingSEXP);
+    Rcpp::traits::input_parameter< int >::type coloring(coloringSEXP);
+    Rcpp::traits::input_parameter< int >::type syncType(syncTypeSEXP);
+    Rcpp::traits::input_parameter< int >::type basicOpt(basicOptSEXP);
+    rcpp_result_gen = Rcpp::wrap(parallel_louvain(links, minGraphSize, C_thresh, threshold, numColors, strongScaling, coloring, syncType, basicOpt));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -42,7 +50,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_FastPG_dedup_links", (DL_FUNC) &_FastPG_dedup_links, 1},
     {"_FastPG_rcpp_parallel_jce", (DL_FUNC) &_FastPG_rcpp_parallel_jce, 1},
-    {"_FastPG_parallel_louvain", (DL_FUNC) &_FastPG_parallel_louvain, 1},
+    {"_FastPG_parallel_louvain", (DL_FUNC) &_FastPG_parallel_louvain, 9},
     {NULL, NULL, 0}
 };
 

--- a/src/parallel_louvain.cpp
+++ b/src/parallel_louvain.cpp
@@ -213,8 +213,18 @@ free(tmpEdgeList);
 free(added);
 }//End of parse_SNAP()
 
-double find_communities(graph * G, long* C_orig) {
+double find_communities(graph * G, 
+                        long* C_orig, 
+                        int minGraphSz ,
+                        double C_thresh ,
+                        double threshold ,
+                        int numColors ,
+                        bool strongScaling ,
+                        int coloring ,
+                        int syncType ,
+                        int basicOpt ){
   
+  long minGraphSize = (long) minGraphSz;
   int nT = 1; //Default is one thread
 #pragma omp parallel
 {
@@ -288,16 +298,6 @@ graph* G_orig = (graph *) malloc (sizeof(graph)); //The original version of the 
 duplicateGivenGraph(G, G_orig);
 
 //Call the clustering algorithm:
-//Call the clustering algorithm:
-bool strongScaling = false;
-int coloring = 1;
-int syncType = 0;
-int numColors = 16;
-double C_thresh = 0.01;
-long minGraphSize = 100000;
-double threshold = 0.000001;
-int basicOpt = 1;
-//if ( opts.strongScaling ) { //Strong scaling enabled
 if(strongScaling){
   //Retain the original copy of the graph:
   graph* G_original = (graph *) malloc (sizeof(graph)); //The original version of the graph
@@ -392,7 +392,15 @@ return final_modularity;
 //'   cluster number that the i'th node in the links matrix has been assigned to.
 //' @export
 // [[Rcpp::export]]
-Rcpp::List parallel_louvain(NumericMatrix links){
+Rcpp::List parallel_louvain(NumericMatrix links, 
+                            int minGraphSize = 1000,
+                            double C_thresh = 0.000001,
+                            double threshold = 0.000000001,
+                            int numColors = 16,
+                            bool strongScaling = false,
+                            int coloring = 1,
+                            int syncType = 0,
+                            int basicOpt = 1){
 
   double modularity = -1;
 
@@ -406,7 +414,16 @@ Rcpp::List parallel_louvain(NumericMatrix links){
   
   long *C_orig = (long *) malloc (G->numVertices * sizeof(long)); assert(C_orig != 0);
   
-  modularity = find_communities(G,C_orig);
+  modularity = find_communities(G,
+                                C_orig,
+                                minGraphSize,
+                                C_thresh,
+                                threshold,
+                                numColors,
+                                strongScaling,
+                                coloring,
+                                syncType,
+                                basicOpt);
   
   for(auto it = clusterLocalMap.begin();it != clusterLocalMap.end(); ++it){
     res[it->first-1]=(int)C_orig[it->second];


### PR DESCRIPTION
…vain call

Removed the hard-coded parameter arguments in the parallel_louvain wrapper of the grappolo source code.  Made default values for the new arguments for all these arguments to match suggestions for the FastPG usecase.  However, users can change these values if wanted when calling parallel_louvain.  But since arguments have defaults, they do NOT have to specified.