### PR TITLE
Replacing nmslibR and Python with RcppHNSW

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Imports:
     RcppParallel (>= 4.4.4),
     flowCore,
     checkmate,
-    nmslibR
+    RcppHNSW
 LinkingTo: 
     Rcpp,
     RcppParallel,

--- a/R/FastPG.R
+++ b/R/FastPG.R
@@ -24,7 +24,6 @@
 #' @param k (3) How many nearest neighbors to choose for each point when
 #'   creating the community graph.
 #' @param num_threads (1) Number of threads to use.
-#' 
 #' @param coloring (1) Integer tuning flag between 0 and 3 that controls the
 #'   type of distance-1 graph coloring. 0 = no coloring; 1 (default) =
 #'   distance-1 graph coloring; 2= 1 with rebalancing; 3= Incomplete coloring
@@ -80,13 +79,14 @@
 #'   
 #' @export
 fastCluster <- function(
-  data, k= 30, num_threads= 1,
+  data, k= 30, num_threads = 1,
   coloring= 1, minGraphSize= 1000, numColors= 16, C_thresh= 1e-6,
   threshold= 1e-9, syncType= 0, basicOpt= 1
 ) {
-  init_nms <- nmslibR::NMSlib$new( input_data= data, space= 'l2', method= 'hnsw' )
-  res <- init_nms$knn_Query_Batch( data, k= k, num_threads= num_threads )
-  ind <- res$knn_idx
+  all_knn <- RcppHNSW::hnsw_knn(data,k=30,distance='l2',M = 16, ef_construction = 200, ef = 10,
+                              verbose = FALSE, progress = "bar", n_threads = num_threads,
+                              grain_size = 1)
+  ind <- all_knn$idx
   
   links <- FastPG::rcpp_parallel_jce(ind)
   links <- dedup_links(links)

--- a/man/fastCluster.Rd
+++ b/man/fastCluster.Rd
@@ -110,7 +110,6 @@ clusters <- FastPG::fastCluster( data, k, num_threads )
 \seealso{
 \itemize{
 \item \code{\link{parallel_louvain}} (Grappolo)
-\item \href{../../nmslibR/doc/the_nmslibR_package.html}{\code{vignette("the_nmslibR_package.html", package = "nmslibR")}}, (HNSW)
 \item \href{../doc/intro.html}{\code{vignette("intro.html", package= "FastPG")}} (FastPG vignette)
 }
 }

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -29,17 +29,7 @@ This package is licensed under the MIT license, except for the Grappolo C++ libr
 
 ## Installation
 
-This R package has dependencies outside of R, e.g. on a python package that wraps a library, `nmslib` [@Boytsov-2013]. You can either set up the dependencies and install locally, pull down a pre-built [Docker](https://www.docker.com) container, or build the Docker container yourself locally.
-
 ### Local install
-
-This R package depends on `nmslibR`[@Mouselimis-2018], which in turn depends on the python module `nmslib`. The instructions to install `nmslib` and its prerequisites are described in the `nmslibR` package [README](https://cran.r-project.org/web/packages/nmslibR/readme/README.html). Note that this setup is somewhat involved, especially if you are not familiar with setting up python modules.
-
-Using python from R requires R to know where to find the python you want to run. In order to avoid specifying the python version every new session (as described in the `nmslibR` document linked above), you can set a shell startup environmental variable `RETICULATE_PYTHON` to the path to python, e.g.:
-
-```{bash}
-export ENV RETICULATE_PYTHON=/usr/bin/python3
-```
 
 Once you have set up the dependencies, you can just install the `FastPG` package from
 GitHub in one of the normal ways. My favorite is:
@@ -130,7 +120,7 @@ Caution: -1 indicates a point that was not clustered; each can be considered the
 
 FastPG utilizes the same three main steps as the phenograph algorithm [@Levine-2015, @Chen-2016], but uses fast, parallel implementations.
 
-* The k nearest neighbors determining step is implemented using hierarchical navigable small world graphs [@Malkov-2016] via the R library nmslibR [@Mouselimis-2018].
+* The k nearest neighbors determining step is implemented using hierarchical navigable small world graphs [@Malkov-2016] via the RcppHNSW.
 * The nearest-neighbor distances are generated using an included parallel Jaccard metric function.
 * Clustering is implemented as community detection in the graph formed from the overlapping "k best friends" for each element. This is done using a parallel Louvain algorithm as implemented by Grappolo [@Lu-2015]. Code for Grappolo has been included within this package; the standalone application with additional functionality is available for download as described in the license section above.
   
@@ -138,9 +128,10 @@ Calling `fastCluster()`  is equivalent to and is essentially implemented as the 
 
 ```{r}
 # Approximate k nearest neighbours
-init_nms <- nmslibR::NMSlib$new( input_data= data, space= 'l2', method= 'hnsw' )
-res <- init_nms$knn_Query_Batch( data, k= k, num_threads= num_threads )
-ind <- res$knn_idx
+all_knn <- RcppHNSW::hnsw_knn(data,k=30,distance='l2',M = 16, ef_construction = 200, ef = 10,
+                              verbose = FALSE, progress = "bar", n_threads = num_threads,
+                              grain_size = 1)
+ind <- all_knn$idx
 
 # Parallel Jaccard metric
 links <- FastPG::rcpp_parallel_jce(ind)


### PR DESCRIPTION
RcppHNSW is a wrapper for R around the HNSW c++ library.  It replaces the first step of FastPG so that the KNN index is built with the RcppHNSW library instead of the existing nmslibR wrapper that required Python.  Testing results look good against the gold standard data (Levine13).  Results for 5 iterations sampling 80,000 cells:

[1] "80000"
Precision: 0.919297971212903
Recall: 0.8797375

Precision: 0.924845246896492
Recall: 0.890525

Precision: 0.925546942611531
Recall: 0.931975

Precision: 0.916563951809679
Recall: 0.896375

Precision: 0.917757197750322
Recall: 0.871525

On a 10-core Intel machine with 64GB of memory, clustering 1.1 million cells (datamatrix_LungCancer_multiATOM_N1113369.txt from https://data.mendeley.com/datasets/nnbfwjvmvw/draft?a=dae895d4-25cd-4bdf-b3e4-57dd31c11e37) takes 1.5 minutes.  Oversampling to 10 million cells from that dataset on the same machine took 11.2 minutes.

I have tried to update all the documentation files as well with the exception of the Docker materials.  Those may need closer review and checking to make sure the RcppHNSW dependency is properly included in the fork.